### PR TITLE
fix: spelling corrections and error message improvements

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2024 Bitcorn
+Copyright 2025 Bitcorn
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/app/graceful.go
+++ b/app/graceful.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ContextWithSignal sets up a signal listener, which will cancel the returned context when
-// an interupt (SIGINT OR SIGTERM) is received.
+// an interrupt (SIGINT OR SIGTERM) is received.
 func ContextWithSignal(ctx context.Context) context.Context {
 	quitCh := make(chan os.Signal, 1)
 	signal.Notify(quitCh, syscall.SIGINT, syscall.SIGTERM)

--- a/app/referral.go
+++ b/app/referral.go
@@ -81,7 +81,7 @@ func NewKOLReferralCode() (string, error) {
 	// First we generate a referral code
 	code, err := NewReferralCode()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to generate root referral code")
+		return "", errors.Wrap(err, "failed to generate KOL referral code")
 	}
 	code = "i" + code[1:]
 	return code, nil

--- a/bitcoin/witness.go
+++ b/bitcoin/witness.go
@@ -4,7 +4,7 @@ import "github.com/cockroachdb/errors"
 
 func ParseWitnessSignatureBIP322(sigBytes []byte) ([][]byte, error) {
 	if len(sigBytes) < 66 {
-		return nil, errors.Errorf("signature length (%d) is invalid, must be atleast 66 bytes", len(sigBytes))
+		return nil, errors.Errorf("signature length (%d) is invalid, must be at least 66 bytes", len(sigBytes))
 	}
 
 	// Extract the number of signatures and the size of each signature


### PR DESCRIPTION
Fixed minor typos and improved error messages in several files:

- LICENSE: Updated copyright year to 2025
- app/graceful.go: Fixed typo in "interrupt" word
- app/referral.go: Clarified error message for KOL referral code
- bitcoin/witness.go: Fixed typo "atleast" to "at least"

Changes are cosmetic and do not affect code functionality.